### PR TITLE
Add more test cases

### DIFF
--- a/extract.yml
+++ b/extract.yml
@@ -345,10 +345,26 @@ tests:
       text: "test http://foo.com/bar/123/foo_&_bar/"
       expected: ["http://foo.com/bar/123/foo_&_bar/"]
 
+    - description: "Extract valid URL http://www.cp.sc.edu/events/65"
+      text: "test http://www.cp.sc.edu/events/65"
+      expected: ["http://www.cp.sc.edu/events/65"]
+
+    - description: "DO NOT include period at the end of URL"
+      text: "test http://twitter.com/."
+      expected: ["http://twitter.com/"]
+
    # A common cause of runaway regex engines.
     - description: "Extract a URL with a ton of trailing periods"
       text: "Test a ton of periods http://example.com/path.........................................."
       expected: ["http://example.com/path"]
+
+    - description: "Extract a URL with a ton of trailing commas"
+      text: "Test a ton of periods http://example.com/,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,"
+      expected: ["http://example.com/"]
+
+    - description: "Extract a URL with a ton of trailing '!'"
+      text: "Test a ton of periods http://example.com/path/!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+      expected: ["http://example.com/path/"]
 
   urls_with_indices:
     - description: "Extract a URL"

--- a/extract.yml
+++ b/extract.yml
@@ -269,9 +269,9 @@ tests:
       text: "@user Try http:// example.com/path"
       expected: ["example.com/path"]
 
-    - description: "DO NOT extract URL without protocol followed by CJK"
-      text: "これは日本語です。example.com/path 中国語example.com/path"
-      expected: ["example.com/path", "example.com/path"]
+    - description: "Extract URL without protocol surrounded by CJK characters"
+      text: "これは日本語です。example.com/path/index.html中国語example.com/path한국"
+      expected: ["example.com/path/index.html", "example.com/path"]
 
     - description: "Extract URLs beginning with a non-breaking space (U+00A0)"
       text: "@user Try http:// example.com/path"
@@ -350,11 +350,11 @@ tests:
       expected: ["http://foo.com/bar/123/foo_&_bar/"]
 
     - description: "Extract valid URL http://www.cp.sc.edu/events/65"
-      text: "test http://www.cp.sc.edu/events/65"
+      text: "test http://www.cp.sc.edu/events/65 test"
       expected: ["http://www.cp.sc.edu/events/65"]
 
     - description: "Extract valid URL http://www.andersondaradio.no.comunidades.net/"
-      text: "test http://www.andersondaradio.no.comunidades.net/"
+      text: "http://www.andersondaradio.no.comunidades.net/ test test"
       expected: ["http://www.andersondaradio.no.comunidades.net/"]
 
     - description: "Extract valid URL ELPAÍS.com"

--- a/extract.yml
+++ b/extract.yml
@@ -269,6 +269,10 @@ tests:
       text: "@user Try http:// example.com/path"
       expected: ["example.com/path"]
 
+    - description: "DO NOT extract URL without protocol followed by CJK"
+      text: "これは日本語です。example.com/path 中国語example.com/path"
+      expected: ["example.com/path", "example.com/path"]
+
     - description: "Extract URLs beginning with a non-breaking space (U+00A0)"
       text: "@user Try http:// example.com/path"
       expected: ["example.com/path"]
@@ -348,6 +352,14 @@ tests:
     - description: "Extract valid URL http://www.cp.sc.edu/events/65"
       text: "test http://www.cp.sc.edu/events/65"
       expected: ["http://www.cp.sc.edu/events/65"]
+
+    - description: "Extract valid URL http://www.andersondaradio.no.comunidades.net/"
+      text: "test http://www.andersondaradio.no.comunidades.net/"
+      expected: ["http://www.andersondaradio.no.comunidades.net/"]
+
+    - description: "Extract valid URL ELPAÍS.com"
+      text: "test ELPAÍS.com"
+      expected: ["ELPAÍS.com"]
 
     - description: "DO NOT include period at the end of URL"
       text: "test http://twitter.com/."


### PR DESCRIPTION
Add test cases for following bug fixes
- Avoid freeze when trying to extract URL followed by punctuations (e.g., http://twitter.com/,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
- Do not include Unicode characters in the domain when protocol is not present (e.g., extract_urls("日本語です。twitter.com") -> ["twitter.com"])
- Do not include period at the end of the URL
