### PR TITLE
Twitter.com autolinks the @ sign in the username

### DIFF
--- a/autolink.yml
+++ b/autolink.yml
@@ -1,12 +1,13 @@
+
 tests:
   usernames:
     - description: "Autolink trailing username"
       text: "text @username"
-      expected: "text @<a class=\"tweet-url username\" href=\"http://twitter.com/username\">username</a>"
+      expected: "text <a class=\"tweet-url username\" href=\"http://twitter.com/username\">@username</a>"
 
     - description: "Autolink username at the beginning"
       text: "@username text"
-      expected: "@<a class=\"tweet-url username\" href=\"http://twitter.com/username\">username</a> text"
+      expected: "<a class=\"tweet-url username\" href=\"http://twitter.com/username\">@username</a> text"
 
     - description: "DO NOT Autolink username preceded by a letter"
       text: "meet@the beach"
@@ -14,27 +15,27 @@ tests:
 
     - description: "Autolink username preceded by puctuation"
       text: "great.@username"
-      expected: "great.@<a class=\"tweet-url username\" href=\"http://twitter.com/username\">username</a>"
+      expected: "great.<a class=\"tweet-url username\" href=\"http://twitter.com/username\">@username</a>"
 
     - description: "Autolink username followed by puctuation"
       text: "@username&^$%^"
-      expected: "@<a class=\"tweet-url username\" href=\"http://twitter.com/username\">username</a>&^$%^"
+      expected: "<a class=\"tweet-url username\" href=\"http://twitter.com/username\">@username</a>&^$%^"
 
     - description: "Autolink username followed by Japanese"
       text: "@usernameの"
-      expected: "@<a class=\"tweet-url username\" href=\"http://twitter.com/username\">username</a>の"
+      expected: "<a class=\"tweet-url username\" href=\"http://twitter.com/username\">@username</a>の"
 
     - description: "Autolink username preceded by Japanese"
       text: "あ@username"
-      expected: "あ@<a class=\"tweet-url username\" href=\"http://twitter.com/username\">username</a>"
+      expected: "あ<a class=\"tweet-url username\" href=\"http://twitter.com/username\">@username</a>"
 
     - description: "Autolink username surrounded by Japanese"
       text: "あ@usernameの"
-      expected: "あ@<a class=\"tweet-url username\" href=\"http://twitter.com/username\">username</a>の"
+      expected: "あ<a class=\"tweet-url username\" href=\"http://twitter.com/username\">@username</a>の"
 
-    - description: "Autolink username in compressed RT"
+    - description: "Autolink usernamt in compressed RT"
       text: "RT@username: long Tweet is loooong"
-      expected: "RT@<a class=\"tweet-url username\" href=\"http://twitter.com/username\">username</a>: long Tweet is loooong"
+      expected: "RT<a class=\"tweet-url username\" href=\"http://twitter.com/username\">@username</a>: long Tweet is loooong"
 
     - description: "DO NOT Autolink username followed by accented latin characters"
       text: "@aliceìnheiro something something"
@@ -46,32 +47,32 @@ tests:
 
     - description: "Autolink username with full-width at sign (U+FF20)"
       text: "＠username"
-      expected: "＠<a class=\"tweet-url username\" href=\"http://twitter.com/username\">username</a>"
+      expected: "<a class=\"tweet-url username\" href=\"http://twitter.com/username\">＠username</a>"
 
     - description: "DO NOT Autolink username over 20 characters"
       text: "@username9012345678901"
-      expected: "@<a class=\"tweet-url username\" href=\"http://twitter.com/username901234567890\">username901234567890</a>1"
+      expected: "<a class=\"tweet-url username\" href=\"http://twitter.com/username901234567890\">@username901234567890</a>1"
 
     - description: "Autolink two usernames"
       text: "@foo @bar"
-      expected: "@<a class=\"tweet-url username\" href=\"http://twitter.com/foo\">foo</a> @<a class=\"tweet-url username\" href=\"http://twitter.com/bar\">bar</a>"
+      expected: "<a class=\"tweet-url username\" href=\"http://twitter.com/foo\">@foo</a> <a class=\"tweet-url username\" href=\"http://twitter.com/bar\">@bar</a>"
 
     - description: "Autolink usernames followed by :"
       text: "@foo: @bar"
-      expected: "@<a class=\"tweet-url username\" href=\"http://twitter.com/foo\">foo</a>: @<a class=\"tweet-url username\" href=\"http://twitter.com/bar\">bar</a>"
+      expected: "<a class=\"tweet-url username\" href=\"http://twitter.com/foo\">@foo</a>: <a class=\"tweet-url username\" href=\"http://twitter.com/bar\">@bar</a>"
 
     - description: "Autolink usernames that are followed by international characters"
       text: "@foo îs in the house"
-      expected: "@<a class=\"tweet-url username\" href=\"http://twitter.com/foo\">foo</a> îs in the house"
+      expected: "<a class=\"tweet-url username\" href=\"http://twitter.com/foo\">@foo</a> îs in the house"
 
   lists:
     - description: "Autolink list preceded by a space"
       text: "text @username/list"
-      expected: "text @<a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list\">username/list</a>"
+      expected: "text <a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list\">@username/list</a>"
 
     - description: "DO NOT Autolink list when space follows slash"
       text: "text @username/ list"
-      expected: "text @<a class=\"tweet-url username\" href=\"http://twitter.com/username\">username</a>/ list"
+      expected: "text <a class=\"tweet-url username\" href=\"http://twitter.com/username\">@username</a>/ list"
 
     - description: "DO NOT Autolink list with empty username"
       text: "text @/list"
@@ -79,7 +80,7 @@ tests:
 
     - description: "Autolink list at the beginning"
       text: "@username/list"
-      expected: "@<a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list\">username/list</a>"
+      expected: "<a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list\">@username/list</a>"
 
     - description: "DO NOT Autolink list preceded by letter"
       text: "meet@the/beach"
@@ -87,31 +88,31 @@ tests:
 
     - description: "Autolink list preceded by puctuation"
       text: "great.@username/list"
-      expected: "great.@<a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list\">username/list</a>"
+      expected: "great.<a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list\">@username/list</a>"
 
     - description: "Autolink list followed by puctuation"
       text: "@username/list&^$%^"
-      expected: "@<a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list\">username/list</a>&^$%^"
+      expected: "<a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list\">@username/list</a>&^$%^"
 
     - description: "Autolink list name over 25 characters (truncated to 25)"
       text: "@username/list567890123456789012345A"
-      expected: "@<a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list567890123456789012345\">username/list567890123456789012345</a>A"
+      expected: "<a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list567890123456789012345\">@username/list567890123456789012345</a>A"
 
     - description: "Autolink list that contains an _"
       text: "text @username/list_name"
-      expected: "text @<a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list_name\">username/list_name</a>"
+      expected: "text <a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list_name\">@username/list_name</a>"
 
     - description: "Autolink list that contains a -"
       text: "text @username/list-name"
-      expected: "text @<a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list-name\">username/list-name</a>"
+      expected: "text <a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list-name\">@username/list-name</a>"
 
     - description: "Autolink list that contains a number"
       text: "text @username/list123"
-      expected: "text @<a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list123\">username/list123</a>"
+      expected: "text <a class=\"tweet-url list-slug\" href=\"http://twitter.com/username/list123\">@username/list123</a>"
 
     - description: "DO NOT Autolink list starting with a number"
       text: "@username/1list"
-      expected: "@<a class=\"tweet-url username\" href=\"http://twitter.com/username\">username</a>/1list"
+      expected: "<a class=\"tweet-url username\" href=\"http://twitter.com/username\">@username</a>/1list"
 
   hashtags:
     - description: "Autolink trailing hashtag"
@@ -634,11 +635,11 @@ tests:
 
     - description: "Autolink all does not allow & without ?"
       text: "Check out: http://example.com/test&@chasesechrist"
-      expected: "Check out: <a href=\"http://example.com/test\">http://example.com/test</a>&@<a class=\"tweet-url username\" href=\"http://twitter.com/chasesechrist\">chasesechrist</a>"
+      expected: "Check out: <a href=\"http://example.com/test\">http://example.com/test</a>&<a class=\"tweet-url username\" href=\"http://twitter.com/chasesechrist\">@chasesechrist</a>"
 
     - description: "Correctly handles URL follower directly by @user"
       text: "See: http://example.com/@user"
-      expected: "See: <a href=\"http://example.com/\">http://example.com/</a>@<a class=\"tweet-url username\" href=\"http://twitter.com/user\">user</a>"
+      expected: "See: <a href=\"http://example.com/\">http://example.com/</a><a class=\"tweet-url username\" href=\"http://twitter.com/user\">@user</a>"
 
     - description: "Correctly handles URL with an @user followed by trailing /"
       text: "See: http://example.com/@user/"


### PR DESCRIPTION
Currently the conformance checks that the @ sign is outside the link, which is incorrect based on the current treatment on the web site.
