### PR TITLE
Add a test case to extract @mention after RT.

### DIFF
--- a/extract.yml
+++ b/extract.yml
@@ -49,6 +49,10 @@ tests:
       text: "@username\n@mention"
       expected: ["username", "mention"]
 
+    - description: "Extract mentions after 'RT'"
+      text: "RT@username RT:@mention RT @test"
+      expected: ["username", "mention", "test"]
+
   mentions_with_indices:
     - description: "Extract a mention at the start"
       text: "@username yo!"


### PR DESCRIPTION
This adds a test case to verify that at_mentions preceded by "RT" or "RT:" are extracted as entity.
