### PR TITLE
Add test cases with hashtags containing Japanese Ditto mark and Turkish 'i'

### DIFF
--- a/extract.yml
+++ b/extract.yml
@@ -639,12 +639,16 @@ tests:
       expected: ["日本語ハッシュタグ"]
 
     - description: "Hashtag with ideographic iteration mark"
-      text: "#云々 #学問のすゝめ #いすゞ #各〻"
-      expected: ["云々", "学問のすゝめ", "いすゞ", "各〻"]
+      text: "#云々 #学問のすゝめ #いすゞ #各〻 #〃"
+      expected: ["云々", "学問のすゝめ", "いすゞ", "各〻", "〃"]
 
     - description: "Hashtags with ş (U+015F)"
       text: "Here’s a test tweet for you: #Ateş #qrşt #ştu #ş"
       expected: ["Ateş", "qrşt", "ştu", "ş"]
+
+    - description: "Hashtags with İ (U+0130) and ı (U+0131)"
+      text: "Here’s a test tweet for you: #İn #ın"
+      expected: ["İn", "ın"]
 
     - description: "Hashtag before punctuations"
       text: "#hashtag: #hashtag; #hashtag, #hashtag. #hashtag! #hashtag?"


### PR DESCRIPTION
I am changing twitter-text-rb/js/java to allow Japanese Ditto mark (〃, U+3003) and Turkish 'i' (ı, U+131 and İ, U+130) in hashtag. This will add test cases for the hashtags with those new characters.
