### PR TITLE
Empty tweets are invalid

### DIFF
--- a/validate.yml
+++ b/validate.yml
@@ -17,6 +17,10 @@ tests:
       text: "のののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののの"
       expected: true
 
+    - description: "Invalid Tweet: no characters (empty)"
+      text: ""
+      expected: false
+
     - description: "Invalid Tweet: 141 characters"
       text: "A lie gets halfway around the world before the truth has a chance to get its pants on. --- Winston Churchill (1874-1965) http://bit.ly/dJpywL"
       expected: false


### PR DESCRIPTION
Hi there -- again :)

This is a simple pull request adding a test in validate.yml. Twitter doesn't seem to allow empty tweets, so I assume empty strings should return "false".

Hope this helps!
