### PR TITLE
Add a test case to not extract .bz2 file name as URL.

### DIFF
--- a/extract.yml
+++ b/extract.yml
@@ -442,6 +442,10 @@ tests:
       text: "$http://twitter.com $twitter.com $http://t.co/abcde $t.co/abcde $t.co $TVI.CA $RBS.CA"
       expected: []
 
+    - description: "DO NOT extract .bz2 file name as URL"
+      text: "long.test.tar.bz2 test.tar.bz2 tar.bz2"
+      expected: []
+
   urls_with_indices:
     - description: "Extract a URL"
       text: "text http://google.com"


### PR DESCRIPTION
Currently a file name ending with '.bz2' is partially extracted as URL because 'bz' is a valid ccTLD. E.g., 'test.tar.bz' in "test.tar.bz2" is extracted as URL.

I'm preparing a branch on twitter-text-rb/js/java to not extract such URL from .bz2 file name. This adds a test case to verify the fix.
