### PR TITLE
Should return correct indices for multiple instances of the same URL

### DIFF
--- a/extract.yml
+++ b/extract.yml
@@ -1,4 +1,3 @@
-
 tests:
   mentions:
     - description: "Extract mention at the begining of a tweet"
@@ -512,6 +511,14 @@ tests:
           indices: [113, 133]
         - url: "http://t.co/FNkPfmii"
           indices: [136, 156]
+
+    - description: "Extract correct indices for duplicate instances of the same URL"
+      text: "http://t.co http://t.co"
+      expected:
+        - url: "http://t.co"
+          indices: [0, 11]
+        - url: "http://t.co"
+          indices: [12, 23]
 
   hashtags:
     - description: "Extract an all-alpha hashtag"


### PR DESCRIPTION
Currently a tweet like "www.example.com www.example.com" will cause (at least the JavaScript version of) extractUrlsWithIndices to return the indices of the first occurrence for all the occurrences.

```
twttr.txt.extractUrlsWithIndices("http://t.co http://t.co")
> [{"url":"http://t.co","indices":[0,11]},{"url":"http://t.co","indices":[0,11]}]
```
