### PR TITLE
Add test cases to catch the case when mentions are preceded by special symbols.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,6 @@ If you are creating a new twitter-text library in a different programming langua
    * Please be sure to provide example input and output as well as a brief description of the problem.
 
 ## Changelog
-  * v1.4.10 - 2012-1-30 [ Git tag v1.4.10]
-    * [FIX] Do not extract mentions preceded by !, @, #, $, %, & or *
-
   * v1.4.9 - 2011-12-01 [ Git tag v1.4.9 ]
     * [FIX] Apply stricter parsing of t.co URLs
     * [FIX] Extract @mention and hashtag before newline

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ If you are creating a new twitter-text library in a different programming langua
    * Please be sure to provide example input and output as well as a brief description of the problem.
 
 ## Changelog
+  * v1.4.10 - 2012-1-30 [ Git tag v1.4.10]
+    * [FIX] Do not extract mentions preceded by !, @, #, $, %, & or *
+
   * v1.4.9 - 2011-12-01 [ Git tag v1.4.9 ]
     * [FIX] Apply stricter parsing of t.co URLs
     * [FIX] Extract @mention and hashtag before newline

--- a/extract.yml
+++ b/extract.yml
@@ -49,6 +49,34 @@ tests:
       text: "@username\n@mention"
       expected: ["username", "mention"]
 
+    - description: "DO NOT extract username preceded by !"
+      test: "f!@kn"
+      expected: []
+
+    - description: "DO NOT extract username preceded by @"
+      test: "f@@kn"
+      expected: []
+
+    - description: "DO NOT extract username preceded by #"
+      test: "f#@kn"
+      expected: []
+
+    - description: "DO NOT extract username preceded by $"
+      test: "f$@kn"
+      expected: []
+
+    - description: "DO NOT extract username preceded by %"
+      test: "f%@kn"
+      expected: []
+
+    - description: "DO NOT extract username preceded by &"
+      test: "f&@kn"
+      expected: []
+
+    - description: "DO NOT extract username preceded by *"
+      test: "f*@kn"
+      expected: []
+
   mentions_with_indices:
     - description: "Extract a mention at the start"
       text: "@username yo!"


### PR DESCRIPTION
I made extraction of mentions slightly more strict.
Now it does not extract mentions precedented by !, @, #, $, %, & and .
This avoids extracting unintended mentions like "f@KN", which, in turn, reduces spams in users mention section.
