### PR TITLE
A URL with a dot preceding the question mark that leads the query params

### DIFF
--- a/extract.yml
+++ b/extract.yml
@@ -469,6 +469,10 @@ tests:
       text: "$http://twitter.com $twitter.com $http://t.co/abcde $t.co/abcde $t.co $TVI.CA $RBS.CA"
       expected: []
 
+    - description: "extract URLS with a dot preceding the question mark of the query params"
+      text: "http://t.co/a.?q=x"
+      expected: ["http://t.co/a.?q=x"]
+
   urls_with_indices:
     - description: "Extract a URL"
       text: "text http://google.com"


### PR DESCRIPTION
...is extracted incorrectly. eg. http://t.co/a.?q=x
