### PR TITLE
Add test cases for hashtags with Latin extended characters.

### DIFF
--- a/autolink.yml
+++ b/autolink.yml
@@ -358,6 +358,10 @@ tests:
       text: "Here’s a test tweet for you: #Ateş #qrşt #ştu #ş"
       expected: "Here’s a test tweet for you: <a href=\"https://twitter.com/#!/search?q=%23Ateş\" title=\"#Ateş\" class=\"tweet-url hashtag\">#Ateş</a> <a href=\"https://twitter.com/#!/search?q=%23qrşt\" title=\"#qrşt\" class=\"tweet-url hashtag\">#qrşt</a> <a href=\"https://twitter.com/#!/search?q=%23ştu\" title=\"#ştu\" class=\"tweet-url hashtag\">#ştu</a> <a href=\"https://twitter.com/#!/search?q=%23ş\" title=\"#ş\" class=\"tweet-url hashtag\">#ş</a>"
 
+    - description: "Autolink a hashtag with Latin extended character"
+      text: "#mûǁae"
+      expected: "<a href=\"https://twitter.com/#!/search?q=%23mûǁae\" title=\"#mûǁae\" class=\"tweet-url hashtag\">#mûǁae</a>"
+
   urls:
     - description: "Autolink URL with pipe character"
       text: "text http://example.com/pipe|character?yes|pipe|character"

--- a/extract.yml
+++ b/extract.yml
@@ -701,6 +701,10 @@ tests:
       text: "#http://twitter.com #https://twitter.com"
       expected: []
 
+    - description: "Extract hashtags with Latin extended characters"
+      text: "#Azərbaycanca #mûǁae #Čeština #Ċaoiṁín"
+      expected: ["Azərbaycanca", "mûǁae", "Čeština", "Ċaoiṁín"]
+
   hashtags_with_indices:
     - description: "Extract a hastag at the start"
       text: "#hashtag here"


### PR DESCRIPTION
This adds test cases for hashtags with Latin extended characters, in order to verify the change in the following pull requests.
https://github.com/twitter/twitter-text-rb/pull/38
https://github.com/twitter/twitter-text-js/pull/44
https://github.com/twitter/twitter-text-java/pull/25
