### PR TITLE
Add test cases for Arabic and Thai hashtags.

### DIFF
--- a/autolink.yml
+++ b/autolink.yml
@@ -358,6 +358,14 @@ tests:
       text: "Here’s a test tweet for you: #Ateş #qrşt #ştu #ş"
       expected: "Here’s a test tweet for you: <a href=\"https://twitter.com/#!/search?q=%23Ateş\" title=\"#Ateş\" class=\"tweet-url hashtag\">#Ateş</a> <a href=\"https://twitter.com/#!/search?q=%23qrşt\" title=\"#qrşt\" class=\"tweet-url hashtag\">#qrşt</a> <a href=\"https://twitter.com/#!/search?q=%23ştu\" title=\"#ştu\" class=\"tweet-url hashtag\">#ştu</a> <a href=\"https://twitter.com/#!/search?q=%23ş\" title=\"#ş\" class=\"tweet-url hashtag\">#ş</a>"
 
+    - description: "Autolink Arabic hashtag"
+      text: "Arabic hashtag: #فارسی #لس_آنجلس"
+      expected: "Arabic hashtag: <a href=\"https://twitter.com/#!/search?q=%23فارسی\" title=\"#فارسی\" class=\"tweet-url hashtag\">#فارسی</a> <a href=\"https://twitter.com/#!/search?q=%23لس_آنجلس\" title=\"#لس_آنجلس\" class=\"tweet-url hashtag\">#لس_آنجلس</a>"
+
+    - description: "Autolink Thai hashtag"
+      text: "Thai hashtag: #รายละเอียด"
+      expected: "Thai hashtag: <a href=\"https://twitter.com/#!/search?q=%23รายละเอียด\" title=\"#รายละเอียด\" class=\"tweet-url hashtag\">#รายละเอียด</a>"
+
   urls:
     - description: "Autolink URL with pipe character"
       text: "text http://example.com/pipe|character?yes|pipe|character"

--- a/extract.yml
+++ b/extract.yml
@@ -701,6 +701,18 @@ tests:
       text: "#http://twitter.com #https://twitter.com"
       expected: []
 
+    - description: "Extract Arabic hashtags"
+      text: "#سیاست #ایران #السياسة #السياح #لغات  #اتمی  #کنفرانس #العربية #الجزيرة #فارسی"
+      expected: ["سیاست", "ایران", "السياسة", "السياح", "لغات", "اتمی", "کنفرانس", "العربية", "الجزيرة", "فارسی"]
+
+    - description: "Extract Arabic hashtags with dash"
+      text: "#برنامه_نویسی  #رییس_جمهور  #رئيس_الوزراء, #ثبت_نام. #لس_آنجلس"
+      expected: ["برنامه_نویسی", "رییس_جمهور", "رئيس_الوزراء", "ثبت_نام", "لس_آنجلس"]
+
+    - description: "Extract Thai hashtags with dash"
+      text: "#ผู้เริ่ม #การเมือง #รายละเอียด #นักท่องเที่ยว #ของขวัญ #สนามบิน #เดินทาง #ประธาน"
+      expected: ["ผู้เริ่ม", "การเมือง", "รายละเอียด", "นักท่องเที่ยว", "ของขวัญ", "สนามบิน", "เดินทาง", "ประธาน"]
+
   hashtags_with_indices:
     - description: "Extract a hastag at the start"
       text: "#hashtag here"


### PR DESCRIPTION
This adds unit tests for extracting and auto-linking Arabic and Thai hashtags.
