### PR TITLE
Add a test case to make sure not to extract hashtags which are part of URL

### DIFF
--- a/extract.yml
+++ b/extract.yml
@@ -713,6 +713,10 @@ tests:
       text: "#http://twitter.com #https://twitter.com"
       expected: []
 
+    - description: "DO NOT extract hashtag if it's a part of URL"
+      text: "http://twitter.com/#hashtag twitter.com/#hashtag"
+      expected: []
+
     - description: "Extract hashtags with Latin extended characters"
       text: "#Azərbaycanca #mûǁae #Čeština #Ċaoiṁín"
       expected: ["Azərbaycanca", "mûǁae", "Čeština", "Ċaoiṁín"]


### PR DESCRIPTION
This adds a test case in extract.yml to make sure that twitter-text doesn't extract hahstags which are part of URL.
