### PR TITLE
Strange auto-linking behaviour on invalid length @usernames

### DIFF
--- a/autolink.yml
+++ b/autolink.yml
@@ -95,7 +95,7 @@ tests:
 
     - description: "Autolink list name over 25 characters (truncated to 25)"
       text: "@username/list567890123456789012345A"
-      expected: "@<a class=\"tweet-url list-slug\" href=\"https://twitter.com/username/list567890123456789012345\">username/list567890123456789012345</a>A"
+      expected: "@<a class=\"tweet-url username\" href=\"https://twitter.com/username\">username</a>/list567890123456789012345A"
 
     - description: "Autolink list that contains an _"
       text: "text @username/list_name"

--- a/autolink.yml
+++ b/autolink.yml
@@ -50,7 +50,7 @@ tests:
 
     - description: "DO NOT Autolink username over 20 characters"
       text: "@username9012345678901"
-      expected: "@<a class=\"tweet-url username\" href=\"https://twitter.com/username901234567890\">username901234567890</a>1"
+      expected: "@username9012345678901"
 
     - description: "Autolink two usernames"
       text: "@foo @bar"


### PR DESCRIPTION
I think it's strange behaviour to auto-link prefixes of invalid length usernames. For example a tweet containing `@username9012345678901` would become `<a href="https://twitter.com/username901234567890">username901234567890</a>1`.

I saw this [happen in the wild](https://twitter.com/thebolditalic/status/277095860372918272) and thought it looked broken. The tweet links to something that user didn't expect it to.

![weird auto link behaviour on usernames](https://f.cloud.github.com/assets/246534/824/b9721700-40a7-11e2-9524-27c6ed5129bc.png)
