### PR TITLE
Twitter actually shows a mention if it is preceded with any mixed

### DIFF
--- a/extract.yml
+++ b/extract.yml
@@ -52,6 +52,18 @@ tests:
       text: "RT@username RT:@mention RT @test"
       expected: ["username", "mention", "test"]
 
+    - description: "Extract mentions after 'rt'"
+      text: "rt@username rt:@mention rt @test"
+      expected: ["username", "mention", "test"]
+
+    - description: "Extract mentions after 'Rt'"
+      text: "Rt@username Rt:@mention Rt @test"
+      expected: ["username", "mention", "test"]
+
+    - description: "Extract mentions after 'rT'"
+      text: "rT@username rT:@mention rT @test"
+      expected: ["username", "mention", "test"]
+
     - description: "DO NOT extract username preceded by !"
       text: "f!@kn"
       expected: []


### PR DESCRIPTION
case of the characters "r" and "t".
https://twitter.com/sono_inf/statuses/310385896321056769 provides
a lower case example. Extracted streams from Gnip and Datasift
confirm this behavior as well.
This work done on the dime of: Simply Measured simplymeasured.com
