### PR TITLE
Keep display case when linking usernames

### DIFF
--- a/autolink.yml
+++ b/autolink.yml
@@ -64,6 +64,10 @@ tests:
       text: "@foo îs in the house"
       expected: "@<a class=\"tweet-url username\" href=\"https://twitter.com/foo\">foo</a> îs in the house"
 
+    - description: "Keep display case when linking MixedCase username"
+      text: "@MixedCase"
+      expected: "＠<a class=\"tweet-url username\" href=\"https://twitter.com/mixedcase\">MixedCase</a>"
+
   lists:
     - description: "Autolink list preceded by a space"
       text: "text @username/list"


### PR DESCRIPTION
Adds a spec for the twitter/twitter-text-rb#94, which is solved (for
that implementation) in twitter/twitter-text-rb#103.
