### PR TITLE
Fix autolink tests

### DIFF
--- a/autolink.yml
+++ b/autolink.yml
@@ -66,7 +66,7 @@ tests:
 
     - description: "Keep display case when linking MixedCase username"
       text: "@MixedCase"
-      expected: "＠<a class=\"tweet-url username\" href=\"https://twitter.com/mixedcase\">MixedCase</a>"
+      expected: "@<a class=\"tweet-url username\" href=\"https://twitter.com/mixedcase\">MixedCase</a>"
 
   lists:
     - description: "Autolink list preceded by a space"

--- a/autolink.yml
+++ b/autolink.yml
@@ -700,10 +700,6 @@ tests:
       text: "$https://twitter.com $twitter.com $http://t.co/abcde $t.co/abcde $t.co $TVI.CA $RBS.CA"
       expected: "$https://twitter.com $twitter.com $http://t.co/abcde $t.co/abcde $t.co $TVI.CA $RBS.CA"
 
-    - description: "Autolink URLs with unicode chars in them"
-      text: "See: http://example.com/tsa-pre✓™ is a link"
-      expected: "See: <a href=\"http://example.com/tsa-pre✓™\">http://example.com/tsa-pre✓™</a> is a link"
-
   cashtags:
     - description: "Autolink a cashtag"
       text: "$STOCK"


### PR DESCRIPTION
1. Fix typo (full-width '@' symbol).
2. Revert #52 since none of the twitter-text implementations pass it and it's not clear how soon the support for Unicode characters in URL will be added.
