### PR TITLE
add .onion

### DIFF
--- a/tld_lib.yml
+++ b/tld_lib.yml
@@ -570,6 +570,7 @@ generic:
 - nyc
 - okinawa
 - ong
+- onion
 - onl
 - ooo
 - org


### PR DESCRIPTION
Add .onion as a TLD, for use with, for example,  https://facebookcorewwwi.onion/.
