### PR TITLE
Fix linking in CJK text

### DIFF
--- a/extract.yml
+++ b/extract.yml
@@ -444,6 +444,10 @@ tests:
       text: "test http://twitter.com/."
       expected: ["http://twitter.com/"]
 
+    - description: "DO NOT extract URL with leading hyphen inside CJK text"
+      text: "ル-twpf.jpル"
+      expected: []
+
     - description: "Extract a URL with '?' in fragment"
       text: "http://tn.com.ar/show/00056158/la-estrella-del-certamen-el-turno-de-pamela-anderson?fb_xd_fragment#?=&cb=fe17523f223b7&relation=parent.parent&transport=fragment&type=resize&height=20&ackdata"
       expected: ["http://tn.com.ar/show/00056158/la-estrella-del-certamen-el-turno-de-pamela-anderson?fb_xd_fragment#?=&cb=fe17523f223b7&relation=parent.parent&transport=fragment&type=resize&height=20&ackdata"]

--- a/extract.yml
+++ b/extract.yml
@@ -448,6 +448,10 @@ tests:
       text: "ル-twpf.jpル"
       expected: []
 
+    - description: "Extract URL with interior hyphen, subdomain, and numbers"
+      text: "www.123-hyphenated-url.com"
+      expected: ["www.123-hyphenated-url.com"]
+
     - description: "Extract a URL with '?' in fragment"
       text: "http://tn.com.ar/show/00056158/la-estrella-del-certamen-el-turno-de-pamela-anderson?fb_xd_fragment#?=&cb=fe17523f223b7&relation=parent.parent&transport=fragment&type=resize&height=20&ackdata"
       expected: ["http://tn.com.ar/show/00056158/la-estrella-del-certamen-el-turno-de-pamela-anderson?fb_xd_fragment#?=&cb=fe17523f223b7&relation=parent.parent&transport=fragment&type=resize&height=20&ackdata"]


### PR DESCRIPTION
URLs without a protocol, with a leading hyphen, with a short TLD inside CJK text
should no longer be linked
