### PR TITLE
Disallow trailing dash in domain regardless of CJK and path

### DIFF
--- a/extract.yml
+++ b/extract.yml
@@ -448,6 +448,10 @@ tests:
       text: "ル-twpf.jpル"
       expected: []
 
+    - description: "DO NOT extract URLs without protocol with a trailing dash in the domain regardless of CJK and path"
+      text: "tw-.com t-.co tw-.com/home t-.co/home ルtw-.comルt-.coルtw-.com/homeルt-.co/homeル"
+      expected: []
+
     - description: "Extract URL with interior hyphen, subdomain, and numbers"
       text: "www.123-hyphenated-url.com"
       expected: ["www.123-hyphenated-url.com"]


### PR DESCRIPTION
Clarifying behavior - already supported by java/js/rb/objc. Also works with https://github.com/twitter/twitter-text-objc/pull/22
